### PR TITLE
Fix invalid XML attribute names

### DIFF
--- a/DemoCleaner3.csproj
+++ b/DemoCleaner3.csproj
@@ -108,6 +108,7 @@
     <Compile Include="ExtClasses\FolderBrowserDialogEx.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="ExtClasses\XmlUtils.cs" />
     <Compile Include="structures\DemoFolder.cs" />
     <Compile Include="ExtClasses\FolderBrowser2.cs" />
     <Compile Include="ExtClasses\FolderBrowserLauncher.cs" />
@@ -121,7 +122,6 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="structures\TimeStringInfo.cs" />
-    <Compile Include="ExtClasses\XmlUtils.cs" />
     <EmbeddedResource Include="DemoInfoForm.resx">
       <DependentUpon>DemoInfoForm.cs</DependentUpon>
     </EmbeddedResource>

--- a/ExtClasses/XmlUtils.cs
+++ b/ExtClasses/XmlUtils.cs
@@ -1,14 +1,35 @@
-﻿using System.Xml;
+﻿using System;
+using System.Xml;
 using System.Collections.Generic;
 
 namespace DemoCleaner3 {
     public static class XmlUtils {
+        private static String NormalizeAttributeName(String name) {
+            String output = "";
+            if (name.Length == 0 || (name[0] >= '0' && name[0] <= '9') )
+            {
+                output += "_";
+            }
+            foreach (var c in name)
+            {
+                if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') ||(c >= 'A' && c <= 'Z') || (c == '-'))
+                {
+                    output += c;
+                }
+                else
+                {
+                    output += "_";
+                }
+            }
+            return output;
+        }
+
         public static XmlNode ExportXml(XmlDocument doc, Dictionary<string, Dictionary<string, string>> map) {
             var node = doc.CreateNode("element", "demoFile", "");
             foreach (var item in map) {
                 var el = doc.CreateNode("element", item.Key, "");
                 foreach (var subItem in item.Value) {
-                    var attr = doc.CreateAttribute(subItem.Key.Replace(' ', '-'));
+                    var attr = doc.CreateAttribute(NormalizeAttributeName(subItem.Key));
                     attr.Value = subItem.Value;
                     el.Attributes.Append(attr);
                 }


### PR DESCRIPTION
While .NET seems to validate the attribute name (try to put a space there…), the validation is half-way. So, while #1 successfully generates XML, the resulting XML is not standard-compliant and cannot be parsed. Sorry for that.

So, I've decided to look at the W3 standard and to filter characters in the attribute names.

BTW, I was unable to compile the project without adding `ExtClasses\XmlUtils.cs` to the csproj.